### PR TITLE
Fix German language key in supported_languages.ts

### DIFF
--- a/src/client/localization/supported_languages.ts
+++ b/src/client/localization/supported_languages.ts
@@ -5,7 +5,7 @@ export const get_supported_languages = () => {
         { title: localization.get_text(`English`), key: "en", flag: "us" },
         { title: localization.get_text(`French`), key: "fr", flag: "fr" },
         { title: localization.get_text(`Spanish`), key: "es", flag: "es" },
-        { title: localization.get_text(`German`), key: "es", flag: "de" }
+        { title: localization.get_text(`German`), key: "de", flag: "de" }
     ] as { title: string, key: Locale, flag: string }[];
 }
 


### PR DESCRIPTION
I made a mistake when I copied the Spanish setting. Should be fixed now.